### PR TITLE
Revert "Run only one CI task in parallel, to avoid conflicts"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,8 +2,6 @@ name: Ruby
 on: [push]
 jobs:
   build:
-    concurrency:
-      group: ${{ github.head_ref ||  github.ref }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### Fixes
 
 * Fix `markdownlint` failure because of old `nodejs` in CI
-* Run only one CI task in parallel, to avoid conflicts
 
 ### Changes
 


### PR DESCRIPTION
Reverts ONLYOFFICE-QA/onlyoffice_iredmail_helper#346

This doesn't work - tasks are still run in parallel